### PR TITLE
easy_download_and_tokenise: make the script more resumable

### DIFF
--- a/languini/dataset_lib/easy_download_and_tokenise.sh
+++ b/languini/dataset_lib/easy_download_and_tokenise.sh
@@ -9,6 +9,8 @@
 # ./languini/dataset_lib/easy_download_and_tokenise.sh
 #
 
+stage=${stage:-0}
+
 # Check if the script is run relatively to the root of languini-kitchen
 if [ ! -f $PWD/languini/dataset_lib/easy_download_and_tokenise.sh ]; then
     echo "Error: Run this script from the root of the repository."
@@ -17,26 +19,30 @@ fi
 
 mkdir -p data
 
-# Download the dataset
-./languini/dataset_lib/books3_download.sh
+if [ "$stage" -le 0 ]; then
+	# Download the dataset
+	./languini/dataset_lib/books3_download.sh
+fi
 
-# Download the list of file names for the languini books splits
-mkdir -p data/books
-wget https://zenodo.org/record/8375423/files/file_list_test_iid.npy -P data/books
-wget https://zenodo.org/record/8375423/files/file_list_test_java.npy -P data/books
-wget https://zenodo.org/record/8375423/files/file_list_test_langlearn.npy -P data/books
-wget https://zenodo.org/record/8375423/files/file_list_test_statistics.npy -P data/books
-wget https://zenodo.org/record/8375423/files/file_list_test_woodworking.npy -P data/books
-wget https://zenodo.org/record/8375423/files/file_list_test_discworld.npy -P data/books
-wget https://zenodo.org/record/8375423/files/file_list_train.npy -P data/books
+if [ "$stage" -le 1 ]; then
+	# Download the list of file names for the languini books splits
+	mkdir -p data/books
+	wget --continue https://zenodo.org/record/8375423/files/file_list_test_iid.npy -P data/books
+	wget --continue https://zenodo.org/record/8375423/files/file_list_test_java.npy -P data/books
+	wget --continue https://zenodo.org/record/8375423/files/file_list_test_langlearn.npy -P data/books
+	wget --continue https://zenodo.org/record/8375423/files/file_list_test_statistics.npy -P data/books
+	wget --continue https://zenodo.org/record/8375423/files/file_list_test_woodworking.npy -P data/books
+	wget --continue https://zenodo.org/record/8375423/files/file_list_test_discworld.npy -P data/books
+	wget --continue https://zenodo.org/record/8375423/files/file_list_train.npy -P data/books
+fi
 
-# Tokenise the languini books data with the default 16k sentencepiece vocabulary.
-python3 languini/dataset_lib/tokenise_languini_books.py --split_npy_file data/books/file_list_test_langlearn.npy --spm_model languini/vocabs/spm_models/books_16384.model
-python3 languini/dataset_lib/tokenise_languini_books.py --split_npy_file data/books/file_list_test_statistics.npy --spm_model languini/vocabs/spm_models/books_16384.model
-python3 languini/dataset_lib/tokenise_languini_books.py --split_npy_file data/books/file_list_test_woodworking.npy --spm_model languini/vocabs/spm_models/books_16384.model
-python3 languini/dataset_lib/tokenise_languini_books.py --split_npy_file data/books/file_list_test_java.npy --spm_model languini/vocabs/spm_models/books_16384.model
-python3 languini/dataset_lib/tokenise_languini_books.py --split_npy_file data/books/file_list_test_discworld.npy --spm_model languini/vocabs/spm_models/books_16384.model
-python3 languini/dataset_lib/tokenise_languini_books.py --split_npy_file data/books/file_list_test_iid.npy --spm_model languini/vocabs/spm_models/books_16384.model
-python3 languini/dataset_lib/tokenise_languini_books.py --split_npy_file data/books/file_list_train.npy --spm_model languini/vocabs/spm_models/books_16384.model
-
-
+if [ "$stage" -le 2 ]; then
+	# Tokenise the languini books data with the default 16k sentencepiece vocabulary.
+	python3 languini/dataset_lib/tokenise_languini_books.py --split_npy_file data/books/file_list_test_langlearn.npy --spm_model languini/vocabs/spm_models/books_16384.model
+	python3 languini/dataset_lib/tokenise_languini_books.py --split_npy_file data/books/file_list_test_statistics.npy --spm_model languini/vocabs/spm_models/books_16384.model
+	python3 languini/dataset_lib/tokenise_languini_books.py --split_npy_file data/books/file_list_test_woodworking.npy --spm_model languini/vocabs/spm_models/books_16384.model
+	python3 languini/dataset_lib/tokenise_languini_books.py --split_npy_file data/books/file_list_test_java.npy --spm_model languini/vocabs/spm_models/books_16384.model
+	python3 languini/dataset_lib/tokenise_languini_books.py --split_npy_file data/books/file_list_test_discworld.npy --spm_model languini/vocabs/spm_models/books_16384.model
+	python3 languini/dataset_lib/tokenise_languini_books.py --split_npy_file data/books/file_list_test_iid.npy --spm_model languini/vocabs/spm_models/books_16384.model
+	python3 languini/dataset_lib/tokenise_languini_books.py --split_npy_file data/books/file_list_train.npy --spm_model languini/vocabs/spm_models/books_16384.model
+fi


### PR DESCRIPTION
- allow to set stage={0,1,2} variable to skip certain parts like this:

```
stage=0 ./languini/dataset_lib/easy_download_and_tokenise.sh # do everything
stage=1 ./languini/dataset_lib/easy_download_and_tokenise.sh # skip large download and untar
stage=2 ./languini/dataset_lib/easy_download_and_tokenise.sh # skip downloading manifests
```

(the stage convention comes from [Kaldi](https://github.com/kaldi-asr/kaldi/blob/master/egs/librispeech/s5/local/lm/train_lm.sh) and ESPnet)

- use wget --continue where possible