### PR TITLE
Support running on CPU

### DIFF
--- a/debug.sh
+++ b/debug.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# debug script for running on single CPU/GPU
+
+project=gpt
+# project=lstm
+
+export WANDB_MODE=disabled
+
+# use "yes" to automatically confirm overwrties of old project folders
+./venv/bin/torchrun --standalone -m pdb languini/projects/$project/main.py tiny --train_batch_size 8 --gradient_accumulation_steps 4 --max_train_steps 512 --decay_steps 512 --compile None
+

--- a/languini/common_lib/experiment_utils.py
+++ b/languini/common_lib/experiment_utils.py
@@ -25,13 +25,13 @@ from languini.common_lib.parallel_utils import is_main_process
 
 
 def check_hardware(config, world_size):
-    config.n_gpus = world_size
-    assert config.train_batch_size % config.n_gpus == 0, \
-            f"Ensure that train_batch_size ({config.train_batch_size}) is a multiple of the number of GPUs available ({config.n_gpus})."
-    assert config.eval_batch_size % config.n_gpus == 0, \
-            f"Ensure that eval_batch_size ({config.eval_batch_size}) is a multiple of the number of GPUs available ({config.n_gpus})."
-    assert config.test_batch_size % config.n_gpus == 0, \
-            f"Ensure that test_batch_size ({config.test_batch_size}) is a multiple of the number of GPUs available ({config.n_gpus})."
+    config.n_workers = world_size
+    assert config.train_batch_size % config.n_workers == 0, \
+            f"Ensure that train_batch_size ({config.train_batch_size}) is a multiple of the number of GPUs available ({config.n_workers})."
+    assert config.eval_batch_size % config.n_workers == 0, \
+            f"Ensure that eval_batch_size ({config.eval_batch_size}) is a multiple of the number of GPUs available ({config.n_workers})."
+    assert config.test_batch_size % config.n_workers == 0, \
+            f"Ensure that test_batch_size ({config.test_batch_size}) is a multiple of the number of GPUs available ({config.n_workers})."
     return config
 
 def setup_log_folder(log_path):

--- a/languini/projects/gpt/configs.py
+++ b/languini/projects/gpt/configs.py
@@ -28,7 +28,7 @@ config_names = [
 def add_exp_name(config):
     """Constructs the name of the log folder used to easily identify the experiment. """
     c = config
-    c.exp_name = ("GPT{}_{}_bsz{}{}_sl{}_coslr{}to{}_h{}_ff{}_nH{}_dH{}_nl{}_clip{}_decay{}k_gpus{}{}_fp16_seed{}{}"
+    c.exp_name = ("GPT{}_{}_bsz{}{}_sl{}_coslr{}to{}_h{}_ff{}_nH{}_dH{}_nl{}_clip{}_decay{}k_workers{}{}_fp16_seed{}{}"
                   .format("_flash" if c.use_flash else "",
                           c.dataset.replace("_", ""),
                           c.train_batch_size,
@@ -43,7 +43,7 @@ def add_exp_name(config):
                           c.n_layers,
                           c.grad_clip_norm,
                           c.decay_steps // 1_000,
-                          c.n_gpus,
+                          c.n_workers,
                           "" if c.compile == "None" else f"_{c.compile}Compile",
                           c.seed,
                           "_debug" if c.debug else "")                          

--- a/languini/projects/gpt/load_throughput.ipynb
+++ b/languini/projects/gpt/load_throughput.ipynb
@@ -738,9 +738,9 @@
     }
    ],
    "source": [
-    "n_gpus = 1\n",
+    "n_workers = 1\n",
     "gradient_accumulation_steps = 32\n",
-    "local_bsz = bsz / n_gpus / gradient_accumulation_steps\n",
+    "local_bsz = bsz / n_workers / gradient_accumulation_steps\n",
     "print(f\"effective local batch size: {local_bsz}\")"
    ]
   },
@@ -759,7 +759,7 @@
     }
    ],
    "source": [
-    "print(f\"{tokens / (n_gpus * tokens_per_second) / 60 / 60:.2f} hours estimated running time\")"
+    "print(f\"{tokens / (n_workers * tokens_per_second) / 60 / 60:.2f} hours estimated running time\")"
    ]
   },
   {

--- a/languini/projects/gpt/main.py
+++ b/languini/projects/gpt/main.py
@@ -52,10 +52,10 @@ from model import Model
 def run(config, logger):
     c = config
     
-    mprint(f"{c.n_gpus} GPUs detected. Using DistributedDataParallel. Local rank: {LOCAL_RANK}")
-    mprint(f"train batch size per GPU: {c.train_batch_size // WORLD_SIZE}")
-    mprint(f"eval batch size per GPU: {c.eval_batch_size // WORLD_SIZE}")
-    mprint(f"test batch size per GPU: {c.test_batch_size // WORLD_SIZE}")
+    mprint(f"{c.n_workers} workers detected. Using DistributedDataParallel. Local rank: {LOCAL_RANK}")
+    mprint(f"train batch size per worker/GPU: {c.train_batch_size // WORLD_SIZE}")
+    mprint(f"eval batch size per worker/GPU: {c.eval_batch_size // WORLD_SIZE}")
+    mprint(f"test batch size per worker/GPU: {c.test_batch_size // WORLD_SIZE}")
     mprint(f"gradient accumulation steps: {c.gradient_accumulation_steps}")
 
     mprint(f"WORLD_SIZE: {WORLD_SIZE}")  # total number of devices

--- a/languini/projects/gpt/main.py
+++ b/languini/projects/gpt/main.py
@@ -52,7 +52,7 @@ from model import Model
 def run(config, logger):
     c = config
     
-    mprint(f"{c.n_workers} workers detected. Using DistributedDataParallel. Local rank: {LOCAL_RANK}")
+    mprint(f"{c.n_workers} workers detected. Using DistributedDataParallel. Local rank: {LOCAL_RANK}. Device: {c.device}")
     mprint(f"train batch size per worker/GPU: {c.train_batch_size // WORLD_SIZE}")
     mprint(f"eval batch size per worker/GPU: {c.eval_batch_size // WORLD_SIZE}")
     mprint(f"test batch size per worker/GPU: {c.test_batch_size // WORLD_SIZE}")
@@ -61,7 +61,6 @@ def run(config, logger):
     mprint(f"WORLD_SIZE: {WORLD_SIZE}")  # total number of devices
     mprint(f"WORLD_RANK: {WORLD_RANK}")  # unique id within all devices
     mprint(f"LOCAL_RANK: {LOCAL_RANK}")  # unique id within the devices of this node
-    c.device = f"cuda:{LOCAL_RANK}"
 
     mprint("Setup data sources ... ")
     # Compute the batch indices for this accelerator.
@@ -104,8 +103,9 @@ def run(config, logger):
     model = Model(config=c)
     if c.compile != "None":
         model = torch.compile(model, mode=c.compile)
-    model = model.to(f"cuda:{LOCAL_RANK}")
-    model = torch.nn.parallel.DistributedDataParallel(model, device_ids=[LOCAL_RANK])  # we always use DDP so loading weights is simpler
+    model = model.to(c.device)
+    device_ids = [LOCAL_RANK] if c.device.type == "cuda" else None # must be None for non-cuda
+    model = torch.nn.parallel.DistributedDataParallel(model, device_ids=device_ids)  # we always use DDP so loading weights is simpler
 
     ## Setup Optimiser
     opt = torch.optim.Adam(model.parameters(), lr=c.max_lr, betas=(0.9, 0.95), eps=1e-08)
@@ -134,7 +134,7 @@ def main():
     """Runs a Languini experiment using a GPT model."""
 
     # initialise distributed processes
-    parallel_utils.init_distributed()
+    device = parallel_utils.init_distributed()
     mp.set_start_method("spawn")
 
     mprint("Languini Experiment")
@@ -156,6 +156,7 @@ def main():
     args = parser.parse_args(sys.argv[2:])
     config = experiment_utils.update_config_given_args(config, args)
     config.project_path = project_path
+    config.device = device
     
     # Check if the config matches the available hardware
     config = experiment_utils.check_hardware(config, world_size=WORLD_SIZE)

--- a/languini/projects/gpt/model.py
+++ b/languini/projects/gpt/model.py
@@ -111,10 +111,14 @@ if __name__ == "__main__":
     c.batch_size = 8
     c.seq_len = 512
     c.vocab_size = 666
-    c.device = 'cuda'
     c.use_flash = False
-    c.n_gpus = torch.cuda.device_count()
-    c.device_batch_size = c.batch_size // c.n_gpus
+    if torch.cuda.is_available():
+        c.device = 'cuda'
+        c.n_workers = torch.cuda.device_count()
+    else:
+        c.device = "cpu"
+        c.n_workers = 1
+    c.device_batch_size = c.batch_size // c.n_workers
 
     model = Model(config=c).to(c.device)
 

--- a/languini/projects/lstm/configs.py
+++ b/languini/projects/lstm/configs.py
@@ -28,7 +28,7 @@ config_names = [
 def add_exp_name(config):
     """Constructs the name of the log folder used to easily identify the experiment. """
     c = config
-    c.exp_name = ("{}LSTM{}_{}_bsz{}_micro{}_sl{}_coslr{}to{}_h{}_ff{}_nH{}_dH{}_nl{}_clip{}_decay{}k_gpus{}{}_fp16_seed{}{}"
+    c.exp_name = ("{}LSTM{}_{}_bsz{}_micro{}_sl{}_coslr{}to{}_h{}_ff{}_nH{}_dH{}_nl{}_clip{}_decay{}k_workers{}{}_fp16_seed{}{}"
                   .format("quasi" if c.is_quasi else "",
                           f"_bl{c.block_length}" if c.is_quasi else "",
                           c.dataset.replace("_", ""),
@@ -44,7 +44,7 @@ def add_exp_name(config):
                           c.n_layers,
                           c.grad_clip_norm,
                           c.decay_steps // 1_000,
-                          c.n_gpus,
+                          c.n_workers,
                           "" if c.compile == "None" else f"_{c.compile}Compile",
                           c.seed,
                           "_debug" if c.debug else "")                          

--- a/languini/projects/lstm/eval.py
+++ b/languini/projects/lstm/eval.py
@@ -16,7 +16,7 @@
 
 # Example
 
-P=languini/projects/lstm/logs/quasiLSTM_bl16_books16384_bsz160_micro1_sl512_coslr0.0006to6e-06_h768_ff3072_nH12_dH64_nl12_clip0.0_decay47k_gpus8_defaultCompile_fp16
+P=languini/projects/lstm/logs/quasiLSTM_bl16_books16384_bsz160_micro1_sl512_coslr0.0006to6e-06_h768_ff3072_nH12_dH64_nl12_clip0.0_decay47k_workers8_defaultCompile_fp16
 CUDA_VISIBLE_DEVICES=0 torchrun --standalone languini/projects/lstm/eval.py \
         --checkpoint_file "$P"/checkpoints/model.pt \
         --config_file "$P"/config.pickle \
@@ -61,9 +61,9 @@ def run(config):
     model = model.to(f"cuda:{LOCAL_RANK}")
 
     # some qlstm models were trained with an earlier version of the codebase which didn't use DDP if training was done on a single gpu.
-    if c.n_gpus > 1:
+    if c.n_workers > 1:
         model = torch.nn.parallel.DistributedDataParallel(model, device_ids=[LOCAL_RANK])  # we always use DDP so we can easily load models 
-    c.n_gpus = 1  # n_gpus must be set to 1 for evaluation in order to compute the correct local batch size
+    c.n_workers = 1  # n_workers must be set to 1 for evaluation in order to compute the correct local batch size
     model, curr_state = train_utils.load_checkpoint(model, c.checkpoint_file)
     mprint(f"Model checkpoint and state loaded from {c.checkpoint_file}")
     

--- a/languini/projects/lstm/load_throughput.ipynb
+++ b/languini/projects/lstm/load_throughput.ipynb
@@ -783,9 +783,9 @@
     }
    ],
    "source": [
-    "n_gpus = 1\n",
+    "n_workers = 1\n",
     "gradient_accumulation_steps = 1\n",
-    "bsz / n_gpus / gradient_accumulation_steps"
+    "bsz / n_workers / gradient_accumulation_steps"
    ]
   },
   {
@@ -803,7 +803,7 @@
     }
    ],
    "source": [
-    "print(f\"{tokens / (n_gpus * tokens_per_second) / 60 / 60:.2f} hours estimated running time\")"
+    "print(f\"{tokens / (n_workers * tokens_per_second) / 60 / 60:.2f} hours estimated running time\")"
    ]
   },
   {

--- a/languini/projects/lstm/main.py
+++ b/languini/projects/lstm/main.py
@@ -54,10 +54,10 @@ from model import Model
 def run(config, logger):
     c = config
     
-    mprint(f"{c.n_gpus} GPUs detected. Using DistributedDataParallel. Local rank: {LOCAL_RANK}")
-    mprint(f"train batch size per GPU: {c.train_batch_size // WORLD_SIZE}")
-    mprint(f"eval batch size per GPU: {c.eval_batch_size // WORLD_SIZE}")
-    mprint(f"test batch size per GPU: {c.test_batch_size // WORLD_SIZE}")
+    mprint(f"{c.n_workers} workers detected. Using DistributedDataParallel. Local rank: {LOCAL_RANK}")
+    mprint(f"train batch size per worker/GPU: {c.train_batch_size // WORLD_SIZE}")
+    mprint(f"eval batch size per worker/GPU: {c.eval_batch_size // WORLD_SIZE}")
+    mprint(f"test batch size per worker/GPU: {c.test_batch_size // WORLD_SIZE}")
     mprint(f"gradient accumulation steps: {c.gradient_accumulation_steps}")
 
     mprint(f"WORLD_SIZE: {WORLD_SIZE}")  # total number of devices

--- a/languini/projects/lstm/model.py
+++ b/languini/projects/lstm/model.py
@@ -121,10 +121,14 @@ if __name__ == "__main__":
     c.block_length = 32
     c.seq_len = 512
     c.vocab_size = 666
-    c.device = 'cuda'
     c.is_quasi = True
-    c.n_gpus = torch.cuda.device_count()
-    c.device_batch_size = c.batch_size // c.n_gpus
+    if torch.cuda.is_available():
+        c.device = 'cuda'
+        c.n_workers = torch.cuda.device_count()
+    else:
+        c.device = "cpu"
+        c.n_workers = 1
+    c.device_batch_size = c.batch_size // c.n_workers
 
     model = Model(config=c).to(c.device)
 

--- a/languini/train_lib/lm_trainer.py
+++ b/languini/train_lib/lm_trainer.py
@@ -61,7 +61,7 @@ def evaluation(config, model, state, data_source, max_steps, last_n=-1, print_pr
         print_progress (bool): simple terminal log for eval.py to display progress.
     """
     c = config
-    local_bsz = config.eval_batch_size // c.n_gpus
+    local_bsz = config.eval_batch_size // c.n_workers
 
     assert last_n <= c.seq_len and last_n != 0, "we cannot eval on the last_n=0 tokens or more tokens than there are in a sequence!"
     assert all(common_utils.flatten(common_utils.traverse(state, func=lambda x: x is None or x.shape[0] == 1))), "all state elements must have batch size 1!"
@@ -276,7 +276,7 @@ class LMTrainer:
 
             load_watch.start()
             total_batch_x, total_batch_y, _ = next(self.train_batches)
-            check(total_batch_x, (c.gradient_accumulation_steps, c.train_batch_size // c.gradient_accumulation_steps // c.n_gpus, c.seq_len))
+            check(total_batch_x, (c.gradient_accumulation_steps, c.train_batch_size // c.gradient_accumulation_steps // c.n_workers, c.seq_len))
             load_watch.pause().count()
 
             for micro_step in range(c.gradient_accumulation_steps):
@@ -287,7 +287,7 @@ class LMTrainer:
                 # select the current micro batch
                 batch_x = total_batch_x[micro_step]
                 batch_y = total_batch_y[micro_step]
-                check(batch_x, (c.train_batch_size // c.gradient_accumulation_steps // c.n_gpus, c.seq_len))
+                check(batch_x, (c.train_batch_size // c.gradient_accumulation_steps // c.n_workers, c.seq_len))
                 bsz, seqlen = batch_x.shape
                 
                 # run forward pass

--- a/languini/train_lib/lm_trainer.py
+++ b/languini/train_lib/lm_trainer.py
@@ -76,7 +76,7 @@ def evaluation(config, model, state, data_source, max_steps, last_n=-1, print_pr
     total_token_count = 0
 
     with torch.no_grad():
-        with torch.cuda.amp.autocast():
+        with torch.cuda.amp.autocast(enabled=c.device.type == "cuda"):
             # distribute the given state over the batch-size
             if state is None:
                 if isinstance(model, torch.nn.parallel.DistributedDataParallel):
@@ -220,7 +220,7 @@ class LMTrainer:
         self.scheduler = scheduler
         self.train_batches = train_batches
         self.eval_batches = eval_batches
-        self.scaler = torch.cuda.amp.GradScaler()
+        self.scaler = torch.cuda.amp.GradScaler(enabled=c.device.type == "cuda")
 
         # log hyperparameters
         train_utils.log_hyperparams(config, self.logger)
@@ -291,7 +291,7 @@ class LMTrainer:
                 bsz, seqlen = batch_x.shape
                 
                 # run forward pass
-                with torch.cuda.amp.autocast():
+                with torch.cuda.amp.autocast(enabled=c.device.type == "cuda"):
                     # get initial state
                     if curr_state is None:
                         if isinstance(self.model, torch.nn.parallel.DistributedDataParallel):


### PR DESCRIPTION
- Renames `n_gpus` to `n_workers` (this breaks backwards compatibility for loading older configs)
- Uses `config.device` variable everywhere and sets it in `init_distributed`
- Automatically disables some functionality that requires cuda when cuda not available
- Introduces `debug.sh` script for running models locally with pdb and without wandb
