### PR TITLE
Don't evaluate on padding

### DIFF
--- a/debug.sh
+++ b/debug.sh
@@ -8,5 +8,5 @@ project=gpt
 export WANDB_MODE=disabled
 
 # use "yes" to automatically confirm overwrties of old project folders
-./venv/bin/torchrun --standalone -m pdb languini/projects/$project/main.py tiny --train_batch_size 8 --gradient_accumulation_steps 4 --max_train_steps 512 --decay_steps 512 --compile None
+./venv/bin/torchrun -m pdb languini/projects/$project/main.py tiny --train_batch_size 8 --gradient_accumulation_steps 4 --max_train_steps 512 --decay_steps 512 --compile None --logger_type tb
 

--- a/languini/train_lib/lm_trainer.py
+++ b/languini/train_lib/lm_trainer.py
@@ -126,7 +126,7 @@ def evaluation(config, model, state, data_source, max_steps, last_n=-1, print_pr
                 check(all_losses, (bsz * last_n,))
 
                 # mask losses that are padded (unlike training, evaluation can result in batches with padded batches)
-                is_padding = batch_x.reshape(-1) == 0 # (bsz * last_n,)
+                is_padding = batch_y.reshape(-1) == 0 # (bsz * last_n,)
                 all_losses = all_losses.masked_fill(is_padding, 0.0)
                 token_count = torch.sum(~is_padding)
 
@@ -176,10 +176,7 @@ def log_eval_stats(eval_data_source, eval_steps, last_n, sp, logger, device):
             str_length += len(str)
 
         # count non-padding tokens
-        if is_padded:
-            token_count += torch.sum(batch_x != 0)
-        else:
-            token_count += batch_x.numel()
+        token_count += torch.sum(batch_y != 0) if is_padded else batch_y.numel()
     
     # sum across accelerators
     dist.all_reduce(str_length, dist.ReduceOp.SUM)


### PR DESCRIPTION
- Fixes a bug where we evaluated the model to predict padding (i.e. the 0 token which is never seen during training), because we compute `is_padding = batch_x == 0` but it should be `is_padding = batch_y == 0` as y will already be padded when x is not yet. The bug barely affects the results as it only occurs at the very end evaluation for at most one position in the sequence.
- Fixes the debug script, avoids debug runs starting a wandb run.

